### PR TITLE
Add documentation for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+CHANGE ME: provide a short description for the pull request
+
+Added:
+
+* CHANGE ME: if applicable, please make a short list with added features/code
+
+Changes and edits:
+
+* CHANGE ME: if applicable, please make a short list with edits and changes
+
+Fixed:
+
+* CHANGE ME: if applicable, please make a short list with fixes
+
+Dependencies:
+
+* CHANGE ME: if applicable, please make a short list added/removed dependencies
+
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This command will start the database as a Docker container in detached mode, exp
 Build special Docker image, which will generate certificates
 
 ```bash
-docker build --target dare-db-tls -f Dockerfile.tls.yml .
+docker build -t dare-db-tls -f Dockerfile.tls.yml .
 ```
 
 Once the image is built, you can run the database as a Docker container with the following command:

--- a/README.md
+++ b/README.md
@@ -116,5 +116,38 @@ func main() {
         return
     }
 }
+```
 
+## How to Contribute
 
+All kind of contributions are welcome (e.g., code, ideas, bugs, comments, documentations, etc.)! 
+If your found a bug open an issue and describe it shortly. If you want to add a feature, feel free to open an issue, assign it to yourself and make a pull request based on your issue. Note that discussion threads are used to discuss ideas. 
+
+How to add a new feature using pull request:
+
+1. Fork the repository (e.g., latest changes must be in ```main``` branch)
+    ```
+    git clone -b main https://github.com/dmarro89/dare-db
+    ```
+2. Create a new branch for your feature. Use number of a newly created issue and keywords (e.g., ```10-implement-feature-ABC```)
+    ```
+    git checkout -b 10-implement-feature-ABC
+    ```
+3. Add changes to the branch
+    ```
+    git add .
+    ```
+4. Commit your changes 
+    ```
+    git commit -am 'add new feature ABC'
+    ```
+5. Push to the branch
+    ```
+    git push origin 10-implement-feature-ABC
+    ```
+6. Open a pull request based on a new branch
+7. Provide a short notice in the pull request according to the following template:
+    + Added: ...
+    + Changed: ...
+    + Fixed: ...
+    + Dependencies: ...

--- a/README.md
+++ b/README.md
@@ -120,14 +120,18 @@ func main() {
 
 ## How to Contribute
 
-All kind of contributions are welcome (e.g., code, ideas, bugs, comments, documentations, etc.)! 
-If your found a bug open an issue and describe it shortly. If you want to add a feature, feel free to open an issue, assign it to yourself and make a pull request based on your issue. Note that discussion threads are used to discuss ideas. 
+All sorts of contributions to this project!  Here's how you can get involved:
 
-How to add a new feature using pull request:
+* *Found a bug?* Let us know! Open an [issue](https://github.com/dmarro89/dare-db/issues) and briefly describe the problem.
+* *Have a great idea for a new feature?* Open an [issue](https://github.com/dmarro89/dare-db/issues) to discuss it. If you'd like to implementing it yourself, you can assign this issue to yourself and create a pull request once the code/improvement/fix is ready.
+* *Want to talk about something related to the project?* [Discussion threads](https://github.com/dmarro89/dare-db/discussions) are the perfect place to brainstorm ideas
 
-1. Fork the repository (e.g., latest changes must be in ```main``` branch)
+
+Here is how you could add your new ```code/improvement/fix``` with a *pull request*:
+
+1. Fork the repository (e.g., latest changes must be in ```develop``` branch)
     ```
-    git clone -b main https://github.com/dmarro89/dare-db
+    git clone -b develop https://github.com/dmarro89/dare-db
     ```
 2. Create a new branch for your feature. Use number of a newly created issue and keywords (e.g., ```10-implement-feature-ABC```)
     ```


### PR DESCRIPTION
A documentation for contributors had been added to readme.md

Added:

* Add documentation for contributors 
* New ```pull_request_template.md``` template

Fixed:

*  option ```-t``` for docker build for tls version


