### PR TITLE
Adding collections handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,7 @@ settings/*
 data/*
 
 # log files
-
 *.log
+
+# special binaries
+dare-db-app

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The primary goal of this project is to offer an in-memory database that leverage
 To run the database as a Docker image, ensure you have Docker installed on your system. First, navigate to the root directory of your project and execute the following command to build the Docker image:
 
 ```bash
-docker build -t dare-db .
+docker build -t dare-db:latest .
 ```
 Once the image is built, you can run the database as a Docker container with the following command (*note: a configuration option ```-e DARE_HOST="0.0.0.0"``` is explicitly set to enable connections from the host machine to the database running within the Docker container*):
 
@@ -30,7 +30,7 @@ This command will start the database as a Docker container in detached mode, exp
 Build special Docker image, which will generate certificates
 
 ```bash
-docker build -t dare-db-tls -f Dockerfile.tls.yml .
+docker build -t dare-db-tls:latest -f Dockerfile.tls.yml .
 ```
 
 Once the image is built, you can run the database as a Docker container with the following command:
@@ -157,3 +157,27 @@ Here is how you could add your new ```code/improvement/fix``` with a *pull reque
     + Changed: ...
     + Fixed: ...
     + Dependencies: ...
+
+
+<details>
+
+<summary>How to Contribute: Dependencies</summary>
+
+## How to Contribute: Dependencies
+
+* [task (a.k.a.: `taskfile`)](https://github.com/go-task/task)
+	+ Install as Go module (globally)
+		```bash
+		go install github.com/go-task/task/v3/cmd/task@latest
+		```
+* [wgo - watcher-go](https://github.com/bokwoon95/wgo)
+	+ Install as Go module (globally)
+		```bash
+		go install github.com/bokwoon95/wgo@latest
+		```
+* [Lefhook (polyglot Git hooks manager)](https://github.com/evilmartians/lefthook/tree/master)
+	+ Install as Go module (globally)
+		```
+		go install github.com/evilmartians/lefthook@latest
+		```
+</details>

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,81 @@
+version: '3'
+
+vars:
+  DOCKER_IMAGE_NAME: "dare-db-tls"
+
+tasks:
+
+  default:
+    silent: true
+    cmds:
+      - task --list-all
+            
+  build:
+    cmds:
+      - go build -v main.go
+      - go build -o dare-db-app main.go
+
+  mod-tidy:
+    aliases: [gmt, tidy]
+    silent: true
+    cmds:
+       - go mod tidy
+
+  run:
+    aliases: [r]
+    env:
+        DARE_HOST: 127.0.0.1
+    cmds:
+      - go run main.go
+
+  run-watch:
+    aliases: [rw]
+    env:
+        DARE_HOST: 127.0.0.1
+    cmds:
+      - wgo -xdir data go run main.go
+      
+  test:
+    aliases: [t]
+    cmds:
+      - go test ./... -v
+  
+  pre-commit-run:
+    aliases: [pcr]
+    silent: true
+    run: once
+    cmds:
+      - lefthook run pre-commit --all-files
+  
+  docker-build:
+    aliases: [db]
+    silent: true
+    run: once
+    cmds:
+      - docker build -t {{.DOCKER_IMAGE_NAME}}:latest -f Dockerfile.tls.yml .
+
+  docker-delete:
+    aliases: [dl]
+    silent: true
+    run: once
+    cmds:
+      - echo "stop container \"{{.DOCKER_IMAGE_NAME}}\""
+      - cmd: docker stop {{.DOCKER_IMAGE_NAME}}
+        ignore_error: true
+      - echo "delete container \"{{.DOCKER_IMAGE_NAME}}\""
+      - cmd: docker rm {{.DOCKER_IMAGE_NAME}}
+        ignore_error: true
+
+  docker-run:
+    aliases: [dr]
+    silent: true
+    run: once
+    cmds:
+      - task: docker-build
+      - task: docker-delete
+      - docker run -d -p "127.0.0.1:2605:2605" -e DARE_HOST="0.0.0.0" -e DARE_PORT=2605 -e DARE_TLS_ENABLED="True" -e DARE_CERT_PRIVATE="/app/settings/cert_private.pem" -e DARE_CERT_PUBLIC="/app/settings/cert_public.pem" --name {{.DOCKER_IMAGE_NAME}} {{.DOCKER_IMAGE_NAME}}:latest
+  
+
+
+
+

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -11,6 +11,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// constants
+const JWT_TIME_TO_LIVE_MINUTES int = 60
+
 type Authenticator interface {
 	GenerateToken(string) (string, error)
 	VerifyToken(token string) (string, error)
@@ -41,7 +44,7 @@ type Claims struct {
 }
 
 func (jwtAuthenticator *JWTAutenticator) GenerateToken(username string) (string, error) {
-	expirationTime := time.Now().Add(50 * time.Minute)
+	expirationTime := time.Now().Add(time.Duration(JWT_TIME_TO_LIVE_MINUTES) * time.Minute)
 	claims := &Claims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -41,7 +41,7 @@ type Claims struct {
 }
 
 func (jwtAuthenticator *JWTAutenticator) GenerateToken(username string) (string, error) {
-	expirationTime := time.Now().Add(5 * time.Minute)
+	expirationTime := time.Now().Add(50 * time.Minute)
 	claims := &Claims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/database/collection.go
+++ b/database/collection.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"sync"
+)
+
+const DEFAULT_COLLECTION = "default"
+
+type CollectionManager struct {
+	collections map[string]*Database
+	mu          sync.RWMutex
+}
+
+func NewCollectionManager() *CollectionManager {
+	return &CollectionManager{
+		collections: make(map[string]*Database),
+	}
+}
+
+func (cm *CollectionManager) AddCollection(name string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.collections[name] = NewDatabase()
+}
+
+func (cm *CollectionManager) GetCollection(name string) (*Database, bool) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	db, exists := cm.collections[name]
+	return db, exists
+}
+
+func (cm *CollectionManager) GetDefaultCollection() *Database {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	db := cm.collections[DEFAULT_COLLECTION]
+	return db
+}
+
+func (cm *CollectionManager) GetCollectionNames() []string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	var collectionNames []string
+	for key := range cm.collections {
+		collectionNames = append(collectionNames, key)
+	}
+	return collectionNames
+}
+
+func (cm *CollectionManager) RemoveCollection(name string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	delete(cm.collections, name)
+}

--- a/database/collection_test.go
+++ b/database/collection_test.go
@@ -1,0 +1,81 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCollectionManager(t *testing.T) {
+	cm := NewCollectionManager()
+
+	// Assert that cm is not nil
+	assert.NotNil(t, cm, "Expected NewCollectionManager to return a non-nil value")
+
+	// Assert that the collections map is initially empty
+	assert.Equal(t, 0, len(cm.collections), "Expected initial collections map to be empty")
+}
+
+func TestAddCollection(t *testing.T) {
+	cm := NewCollectionManager()
+	cm.AddCollection("test-collection")
+
+	// Assert that the collections map contains exactly one collection
+	assert.Equal(t, 1, len(cm.collections), "Expected collections map to have 1 collection")
+
+	// Assert that 'test-collection' was added to the collections map
+	_, exists := cm.collections["test-collection"]
+	assert.True(t, exists, "Expected collection 'test-collection' to be added")
+}
+
+func TestGetCollection(t *testing.T) {
+	cm := NewCollectionManager()
+	cm.AddCollection("test-collection")
+
+	// Assert that the collection exists and is not nil
+	db, exists := cm.GetCollection("test-collection")
+	assert.True(t, exists, "Expected collection 'test-collection' to exist")
+	assert.NotNil(t, db, "Expected non-nil database for collection 'test-collection'")
+}
+
+func TestGetCollectionNotExist(t *testing.T) {
+	cm := NewCollectionManager()
+
+	// Assert that a nonexistent collection returns false
+	_, exists := cm.GetCollection("nonexistent-collection")
+	assert.False(t, exists, "Expected nonexistent collection to return false")
+}
+
+func TestGetDefaultCollection(t *testing.T) {
+	cm := NewCollectionManager()
+	cm.AddCollection(DEFAULT_COLLECTION)
+
+	// Assert that the default collection is not nil
+	db := cm.GetDefaultCollection()
+	assert.NotNil(t, db, "Expected non-nil database for default collection")
+}
+
+func TestGetCollectionNames(t *testing.T) {
+	cm := NewCollectionManager()
+	cm.AddCollection("collection1")
+	cm.AddCollection("collection2")
+
+	// Retrieve collection names and assert they match the expected names
+	names := cm.GetCollectionNames()
+	expectedNames := []string{"collection1", "collection2"}
+
+	assert.ElementsMatch(t, expectedNames, names, "Expected all collection names to be returned")
+}
+
+func TestRemoveCollection(t *testing.T) {
+	cm := NewCollectionManager()
+	cm.AddCollection("collection-to-remove")
+
+	// Remove the collection and assert the collections map is empty
+	cm.RemoveCollection("collection-to-remove")
+	assert.Equal(t, 0, len(cm.collections), "Expected collections map to be empty")
+
+	// Assert that the collection no longer exists
+	_, exists := cm.collections["collection-to-remove"]
+	assert.False(t, exists, "Expected collection 'collection-to-remove' to be removed")
+}

--- a/database/db.go
+++ b/database/db.go
@@ -26,6 +26,13 @@ func (db *Database) Get(key string) string {
 	return db.dict.Get(key)
 }
 
+func (db *Database) GetAllItems() map[string]string {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	return db.dict.GetAllItems()
+}
+
 func (db *Database) Set(key string, value string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -3,7 +3,10 @@
 package database
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDatabase_SetAndGet(t *testing.T) {
@@ -20,6 +23,24 @@ func TestDatabase_SetAndGet(t *testing.T) {
 	result := db.Get(key)
 	if result != value {
 		t.Errorf("Expected %v, got %v", value, result)
+	}
+}
+
+func TestDatabase_GetAllItems(t *testing.T) {
+	db := NewDatabase()
+
+	key := "testKey"
+	value := "testValue"
+
+	for i := 0; i < 10; i++ {
+		db.Set(fmt.Sprintf("%s%d", key, i), fmt.Sprintf("%s%d", value, i))
+	}
+
+	result := db.GetAllItems()
+	assert.Equal(t, 10, len(result))
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, fmt.Sprintf("%s%d", value, i), result[fmt.Sprintf("%s%d", key, i)])
 	}
 }
 

--- a/examples/python/.gitignore
+++ b/examples/python/.gitignore
@@ -1,0 +1,79 @@
+# folders
+scripts/*
+# test files
+test_file_*
+
+# extentions
+*.csv
+*.txt
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/examples/python/daredb_tester.py
+++ b/examples/python/daredb_tester.py
@@ -156,7 +156,7 @@ class DareDBSamplerForCollections(DareDBManageCollections):
         """Populates database with sample data entries."""
 
         self.create(collection_name)
-        url = f"{base_url}/collections/{collection_name}"
+        url = f"{base_url}/collections/{collection_name}/set"
         logger.debug(f"Populate DB with sample data via URL (collection: {collection_name}): {url}")
 
         for i in range(self.MAX_REQUESTS):
@@ -166,7 +166,7 @@ class DareDBSamplerForCollections(DareDBManageCollections):
 
     def get_all_items(self, collection_name: str = "sample"):
 
-        url = f"{base_url}/collections/{collection_name}/getAllItems"
+        url = f"{base_url}/collections/{collection_name}/items"
         response = self.send_get_with_jwt(url)
         if response.status_code == 200:
             logger.info(f"\n{json.dumps(response.json(), indent=2)}")

--- a/examples/python/daredb_tester.py
+++ b/examples/python/daredb_tester.py
@@ -1,0 +1,193 @@
+import json
+import logging
+import os
+import uuid
+
+import urllib3
+from dotenv import load_dotenv
+from requests import delete, get, post
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
+
+urllib3.disable_warnings()
+logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+# logging.basicConfig(level=logging.DEBUG, format="%(name)s - %(levelname)s - %(message)s")
+
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+
+def load_credentials():
+    """
+    Loads base URL, username, and password from environment variables.
+    """
+    base_url = os.getenv("BASE_URL") or "https://127.0.0.1:2605"
+    username = os.getenv("DB_USERNAME") or "admin"
+    password = os.getenv("DB_PASSWORD") or "password"
+    return base_url, username, password
+
+
+class DareDBPyClientBase:
+
+    def __init__(self, username: str, password: str, base_url: str):
+        self.username = username
+        self.password = password
+        self.base_url = base_url
+        self.jwt_token = None
+        self.get_jwt_token()
+
+    def get_jwt_token(self):
+        """Retrieves JWT token by performing a login with username and password."""
+
+        self.auth_url = f"{self.base_url}/login"
+        logger.info(f"URL to get JWT token: {self.auth_url}")
+
+        if not self.jwt_token:
+            try:
+                response = post(self.auth_url, auth=HTTPBasicAuth(self.username, self.password), verify=False)
+                response.raise_for_status()
+            except RequestException as e:
+                logger.error(f"Error getting JWT token: {e}")
+
+                raise
+            logger.debug(f"response.content: {response.content}")
+            token_data = response.json()
+            self.jwt_token = token_data.get("token")
+
+        return self.jwt_token
+
+    def build_headers_with_jwt(self, jwt_token=None):
+        """Constructs the header dictionary with authorization token."""
+        token = jwt_token or self.jwt_token
+        headers = {"Authorization": f"{token}", "Content-Type": "application/json"}
+        return headers
+
+    def send_post_with_jwt(self, url: str, data: dict = None):
+        """Sends a POST request with provided URL, data, and JWT headers."""
+        headers = self.build_headers_with_jwt()
+        try:
+            response = post(url, headers=headers, data=json.dumps(data), verify=False)
+            return response
+        except RequestException as e:
+            logger.error(f"Error sending POST request: {e}")
+            raise
+
+    def send_get_with_jwt(self, url: str):
+        """Sends a GET request with provided URL, and JWT headers."""
+        headers = self.build_headers_with_jwt()
+        try:
+            response = get(url, headers=headers, verify=False)
+            return response
+        except RequestException as e:
+            logger.error(f"Error sending POST request: {e}")
+            raise
+
+    def send_delete_with_jwt(self, url: str):
+        """Sends a DELETE request with provided URL, and JWT headers."""
+        headers = self.build_headers_with_jwt()
+        try:
+            response = delete(url, headers=headers, verify=False)
+            return response
+        except RequestException as e:
+            logger.error(f"Error sending POST request: {e}")
+            raise
+
+    def log_response(self, response):
+        if response.status_code not in [200, 201]:
+            if response.status_code == 404:
+                logger.error(f"HTTP Code: {response.status_code}; content: {response.content}, url: {response.url}")
+                return
+            logger.error(f"HTTP Code: {response.status_code}; content: {response.content}")
+
+
+class DareDBDataSamplerSimple(DareDBPyClientBase):
+
+    def populate_db_with_sample_data(self):
+        """Populates database with sample data entries."""
+
+        url = f"{base_url}/set"
+        logger.debug(f"Populate DB with sample data via URL: {url}")
+        MAX_REQUESTS = 5
+        for i in range(MAX_REQUESTS):
+            data = {f"key_{i}_{uuid.uuid4()}": f"value_{i}"}
+            response = self.send_post_with_jwt(url, data)
+            self.log_response(response)
+
+
+class DareDBManageCollections(DareDBPyClientBase):
+    MAX_COLLECTIONS = 5
+
+    def create(self, name: str = "sample"):
+        url = f"{base_url}/collections/{name}"
+        response = self.send_post_with_jwt(url)
+        self.log_response(response)
+
+    def create_multiple(self):
+
+        collection_name = "sample"
+        for i in range(self.MAX_COLLECTIONS):
+            url = f"{base_url}/collections/{collection_name}_{i}"
+            response = self.send_post_with_jwt(url)
+            self.log_response(response)
+
+    def delete_multiple(self):
+        collection_name = "sample"
+        for i in range(self.MAX_COLLECTIONS):
+            url = f"{base_url}/collections/{collection_name}_{i}"
+            response = self.send_delete_with_jwt(url)
+            self.log_response(response)
+
+    def list(self):
+        url = f"{base_url}/collections"
+        response = self.send_get_with_jwt(url)
+        if response.status_code == 200:
+            logger.info(f"\n{json.dumps(response.json(), indent=2)}")
+        else:
+            self.log_response(response)
+
+
+class DareDBSamplerForCollections(DareDBManageCollections):
+
+    MAX_REQUESTS = 5
+
+    def populate(self, collection_name: str = "sample"):
+        """Populates database with sample data entries."""
+
+        self.create(collection_name)
+        url = f"{base_url}/collections/{collection_name}"
+        logger.debug(f"Populate DB with sample data via URL (collection: {collection_name}): {url}")
+
+        for i in range(self.MAX_REQUESTS):
+            data = {f"key_{i}_{uuid.uuid4()}": f"value_{i} in collection: {collection_name}"}
+            response = self.send_post_with_jwt(url, data)
+            self.log_response(response)
+
+    def get_all_items(self, collection_name: str = "sample"):
+
+        url = f"{base_url}/collections/{collection_name}/getAllItems"
+        response = self.send_get_with_jwt(url)
+        if response.status_code == 200:
+            logger.info(f"\n{json.dumps(response.json(), indent=2)}")
+        else:
+            self.log_response(response)
+
+
+if __name__ == "__main__":
+
+    base_url, username, password = load_credentials()
+
+    sampler = DareDBDataSamplerSimple(username, password, base_url)
+    sampler.populate_db_with_sample_data()
+
+    collections = DareDBManageCollections(username, password, base_url)
+
+    collections.create()
+    collections.create_multiple()
+    collections.list()
+    collections.delete_multiple()
+
+    sampler_collections = DareDBSamplerForCollections(username, password, base_url)
+    sampler_collections.populate()
+    sampler_collections.get_all_items()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dmarro89/dare-db
 go 1.22.3
 
 require (
-	github.com/dmarro89/go-redis-hashtable v0.0.6
+	github.com/dmarro89/go-redis-hashtable v0.0.7
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.3 h1:QXwFc8cFOR2dSa/gE6o/HokBMWtLUaNDVd+22aKHeEA=
 github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIXMPAkHc=
-github.com/dmarro89/go-redis-hashtable v0.0.6 h1:BZV2OopoUGMaT4djWXIwryQkMf4OgKQ2sP+ZL8TnVHo=
-github.com/dmarro89/go-redis-hashtable v0.0.6/go.mod h1:GJxzF4dkIF7HT+kXi5X1gfJOhNJ3aNannR0LZciOh0s=
+github.com/dmarro89/go-redis-hashtable v0.0.7 h1:XkckTjUlR2yNPmLQBT826YK6swBbKufr4Teyy3gQvHI=
+github.com/dmarro89/go-redis-hashtable v0.0.7/go.mod h1:GJxzF4dkIF7HT+kXi5X1gfJOhNJ3aNannR0LZciOh0s=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/server/dare-server.go
+++ b/server/dare-server.go
@@ -51,22 +51,22 @@ func (srv *DareServer) CreateMux(authorizer auth.Authorizer, authenticator auth.
 	mux.HandleFunc(
 		fmt.Sprintf(`GET /get/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerGetById))
 	mux.HandleFunc(
-		`GET /getAllItems`, middleware.HandleFunc(srv.HandlerGetPaginatedItems))
+		`GET /items`, middleware.HandleFunc(srv.HandlerGetPaginatedItems))
 	mux.HandleFunc("POST /set", middleware.HandleFunc(srv.HandlerSet))
 	mux.HandleFunc(fmt.Sprintf(`DELETE /delete/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerDelete))
 	mux.HandleFunc("POST /login", srv.HandlerLogin)
 	mux.HandleFunc(
-		fmt.Sprintf(`GET /collections/get/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerGetCollection))
+		fmt.Sprintf(`GET /collections/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerGetCollection))
 	mux.HandleFunc(
 		`GET /collections`, middleware.HandleFunc(srv.HandlerGetCollections))
-	mux.HandleFunc(fmt.Sprintf("POST /collections/create/{%s}", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCreateCollection))
-	mux.HandleFunc(fmt.Sprintf(`DELETE /collections/delete/{%s}`, COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerDeleteCollection))
+	mux.HandleFunc(fmt.Sprintf("POST /collections/{%s}", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCreateCollection))
+	mux.HandleFunc(fmt.Sprintf(`DELETE /collections/{%s}`, COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerDeleteCollection))
 	mux.HandleFunc(
-		fmt.Sprintf(`GET /{%s}/get/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionGetById))
+		fmt.Sprintf(`GET /collections/{%s}/get/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionGetById))
 	mux.HandleFunc(
-		`GET /{%s}/getAllItems`, middleware.HandleFunc(srv.HandlerGetPaginatedCollectionItems))
-	mux.HandleFunc(fmt.Sprintf("POST /{%s}/set", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCollectionSet))
-	mux.HandleFunc(fmt.Sprintf(`DELETE /{%s}/delete/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionDelete))
+		fmt.Sprintf(`GET /collections/{%s}/items`, COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerGetPaginatedCollectionItems))
+	mux.HandleFunc(fmt.Sprintf("POST /collections/{%s}/set", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCollectionSet))
+	mux.HandleFunc(fmt.Sprintf(`DELETE /collections/{%s}/delete/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionDelete))
 	return mux
 }
 

--- a/server/dare-server.go
+++ b/server/dare-server.go
@@ -10,6 +10,7 @@ import (
 )
 
 const KEY_PARAM = "key"
+const COLLECTION_NAME_PARAM = "collectionName"
 
 type IDare interface {
 	CreateMux(auth.Authorizer, auth.Authenticator) *http.ServeMux
@@ -20,14 +21,17 @@ type IDare interface {
 }
 
 type DareServer struct {
-	db        *database.Database
-	userStore *auth.UserStore
+	userStore         *auth.UserStore
+	collectionManager *database.CollectionManager
 }
 
 func NewDareServer(db *database.Database, userStore *auth.UserStore) *DareServer {
+	collectionManager := database.NewCollectionManager()
+	collectionManager.AddCollection(database.DEFAULT_COLLECTION)
+
 	return &DareServer{
-		db:        db,
-		userStore: userStore,
+		userStore:         userStore,
+		collectionManager: collectionManager,
 	}
 }
 
@@ -48,6 +52,16 @@ func (srv *DareServer) CreateMux(authorizer auth.Authorizer, authenticator auth.
 	mux.HandleFunc("POST /set", middleware.HandleFunc(srv.HandlerSet))
 	mux.HandleFunc(fmt.Sprintf(`DELETE /delete/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerDelete))
 	mux.HandleFunc("POST /login", srv.HandlerLogin)
+	mux.HandleFunc(
+		fmt.Sprintf(`GET /collections/get/{%s}`, KEY_PARAM), middleware.HandleFunc(srv.HandlerGetCollection))
+	mux.HandleFunc(
+		`GET /collections`, middleware.HandleFunc(srv.HandlerGetCollections))
+	mux.HandleFunc(fmt.Sprintf("POST /collections/create/{%s}", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCreateCollection))
+	mux.HandleFunc(fmt.Sprintf(`DELETE /collections/delete/{%s}`, COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerDeleteCollection))
+	mux.HandleFunc(
+		fmt.Sprintf(`GET /{%s}/get/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionGetById))
+	mux.HandleFunc(fmt.Sprintf("POST /{%s}/set", COLLECTION_NAME_PARAM), middleware.HandleFunc(srv.HandlerCollectionSet))
+	mux.HandleFunc(fmt.Sprintf(`DELETE /{%s}/delete/{%s}`, COLLECTION_NAME_PARAM, KEY_PARAM), middleware.HandleFunc(srv.HandlerCollectionDelete))
 	return mux
 }
 
@@ -63,7 +77,42 @@ func (srv *DareServer) HandlerGetById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val := srv.db.Get(key)
+	val := srv.collectionManager.GetDefaultCollection().Get(key)
+	if val == "" {
+		http.Error(w, fmt.Sprintf(`Key "%v" not found`, key), http.StatusNotFound)
+		return
+	}
+
+	response, err := json.Marshal(map[string]string{key: val})
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(response)
+}
+
+func (srv *DareServer) HandlerCollectionGetById(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	collection, exists := srv.collectionManager.GetCollection(collectionName)
+	if !exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" not found`, collectionName), http.StatusNotFound)
+		return
+	}
+
+	key := r.PathValue(KEY_PARAM)
+	if key == "" {
+		http.Error(w, `url path param "key" cannot be empty`, http.StatusBadRequest)
+		return
+	}
+
+	val := collection.Get(key)
 	if val == "" {
 		http.Error(w, fmt.Sprintf(`Key "%v" not found`, key), http.StatusNotFound)
 		return
@@ -94,7 +143,7 @@ func (srv *DareServer) HandlerSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for key, value := range data {
-		err = srv.db.Set(key, value)
+		err = srv.collectionManager.GetDefaultCollection().Set(key, value)
 		if err != nil {
 			http.Error(w, "Error saving data", http.StatusInternalServerError)
 			return
@@ -102,7 +151,37 @@ func (srv *DareServer) HandlerSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
+}
 
+func (srv *DareServer) HandlerCollectionSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var data map[string]string
+	err := json.NewDecoder(r.Body).Decode(&data)
+	if err != nil {
+		http.Error(w, "Invalid JSON format, the body must be in the form of {\"key\": \"value\"}", http.StatusBadRequest)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	collection, exists := srv.collectionManager.GetCollection(collectionName)
+	if !exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" not found`, collectionName), http.StatusNotFound)
+		return
+	}
+
+	for key, value := range data {
+		err = collection.Set(key, value)
+		if err != nil {
+			http.Error(w, "Error saving data", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (srv *DareServer) HandlerDelete(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +196,34 @@ func (srv *DareServer) HandlerDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := srv.db.Delete(key)
+	err := srv.collectionManager.GetDefaultCollection().Delete(key)
+	if err != nil {
+		http.Error(w, "Error deleting data", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (srv *DareServer) HandlerCollectionDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	collection, exists := srv.collectionManager.GetCollection(collectionName)
+	if !exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" not found`, collectionName), http.StatusNotFound)
+		return
+	}
+
+	key := r.PathValue(KEY_PARAM)
+	if key == "" {
+		http.Error(w, `url path param "key" cannot be empty`, http.StatusBadRequest)
+		return
+	}
+
+	err := collection.Delete(key)
 	if err != nil {
 		http.Error(w, "Error deleting data", http.StatusInternalServerError)
 		return
@@ -153,4 +259,91 @@ func (srv *DareServer) HandlerLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
 	}
+}
+
+func (srv *DareServer) HandlerGetCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	collection, exists := srv.collectionManager.GetCollection(collectionName)
+	if !exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" not found`, collectionName), http.StatusNotFound)
+		return
+	}
+
+	key := r.PathValue(KEY_PARAM)
+	if key == "" {
+		http.Error(w, `url path param "key" cannot be empty`, http.StatusBadRequest)
+		return
+	}
+
+	val := collection.Get(key)
+	if val == "" {
+		http.Error(w, fmt.Sprintf(`Key "%v" not found`, key), http.StatusNotFound)
+		return
+	}
+
+	response, err := json.Marshal(map[string]string{key: val})
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(response)
+}
+
+func (srv *DareServer) HandlerGetCollections(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response, err := json.Marshal(srv.collectionManager.GetCollectionNames())
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(response)
+
+}
+
+func (srv *DareServer) HandlerCreateCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	_, exists := srv.collectionManager.GetCollection(collectionName)
+	if exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" already exists`, collectionName), http.StatusBadRequest)
+		return
+	}
+
+	srv.collectionManager.AddCollection(collectionName)
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (srv *DareServer) HandlerDeleteCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	collectionName := r.PathValue(COLLECTION_NAME_PARAM)
+	_, exists := srv.collectionManager.GetCollection(collectionName)
+	if !exists {
+		http.Error(w, fmt.Sprintf(`Collection "%s" not exists`, collectionName), http.StatusBadRequest)
+		return
+	}
+
+	srv.collectionManager.RemoveCollection(collectionName)
+	w.WriteHeader(http.StatusOK)
 }

--- a/server/dare-server_test.go
+++ b/server/dare-server_test.go
@@ -496,3 +496,262 @@ func TestHandlerDeleteCollection(t *testing.T) {
 	_, exists := srv.collectionManager.GetCollection("test-collection")
 	assert.False(t, exists)
 }
+
+// Test handler for successful pagination
+func TestHandlerGetPaginatedItems_Success(t *testing.T) {
+	collectionManager := database.NewCollectionManager()
+	collectionManager.AddCollection(database.DEFAULT_COLLECTION)
+	srv := &DareServer{
+		collectionManager: collectionManager,
+	}
+	// Mock the default collection and add multiple items
+	collection := srv.collectionManager.GetDefaultCollection()
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+	collection.Set("key3", "value3")
+	collection.Set("key4", "value4")
+
+	// Simulate HTTP GET request for page 1 with 2 items per page
+	req := httptest.NewRequest(http.MethodGet, "/items?page=1&pageSize=2", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the handler
+	srv.HandlerGetPaginatedItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 2, "Expected 2 items in paginated response")
+
+	assert.Equal(t, float64(1), responseBody["page"], "Expected page 1")
+	assert.Equal(t, float64(2), responseBody["pageSize"], "Expected pageSize 2")
+}
+
+// Test handler for a different page
+func TestHandlerGetPaginatedItems_Page2(t *testing.T) {
+	collectionManager := database.NewCollectionManager()
+	collectionManager.AddCollection(database.DEFAULT_COLLECTION)
+	srv := &DareServer{
+		collectionManager: collectionManager,
+	}
+	// Mock the default collection and add multiple items
+	collection := srv.collectionManager.GetDefaultCollection()
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+	collection.Set("key3", "value3")
+	collection.Set("key4", "value4")
+
+	// Simulate HTTP GET request for page 2 with 2 items per page
+	req := httptest.NewRequest(http.MethodGet, "/items?page=2&pageSize=2", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the handler
+	srv.HandlerGetPaginatedItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 2, "Expected 2 items in paginated response")
+
+	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
+	assert.Equal(t, float64(2), responseBody["pageSize"], "Expected pageSize 2")
+}
+
+// Test handler when no items are available for the given page
+func TestHandlerGetPaginatedItems_EmptyPage(t *testing.T) {
+	collectionManager := database.NewCollectionManager()
+	collectionManager.AddCollection(database.DEFAULT_COLLECTION)
+	srv := &DareServer{
+		collectionManager: collectionManager,
+	}
+
+	// Mock the default collection and add only a few items
+	collection := srv.collectionManager.GetDefaultCollection()
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+
+	// Simulate HTTP GET request for page 2 with 5 items per page (no data should exist for page 2)
+	req := httptest.NewRequest(http.MethodGet, "/items?page=2&pageSize=5", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the handler
+	srv.HandlerGetPaginatedItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 0, "Expected 0 items for empty page")
+
+	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
+	assert.Equal(t, float64(5), responseBody["pageSize"], "Expected pageSize 5")
+}
+
+// Test handler for invalid method
+func TestHandlerGetPaginatedItems_InvalidMethod(t *testing.T) {
+	collectionManager := database.NewCollectionManager()
+	collectionManager.AddCollection(database.DEFAULT_COLLECTION)
+	srv := &DareServer{
+		collectionManager: collectionManager,
+	}
+
+	// Simulate HTTP POST request (invalid method)
+	req := httptest.NewRequest(http.MethodPost, "/items", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the handler
+	srv.HandlerGetPaginatedItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "Expected status 405 Method Not Allowed")
+}
+
+func TestHandlerGetPaginatedCollectionItems_Success(t *testing.T) {
+	srv := &DareServer{
+		collectionManager: database.NewCollectionManager(),
+	}
+
+	// Mock a collection with multiple items
+	srv.collectionManager.AddCollection("test-collection")
+	collection, _ := srv.collectionManager.GetCollection("test-collection")
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+	collection.Set("key3", "value3")
+	collection.Set("key4", "value4")
+
+	// Simulate HTTP GET request for page 1 with 2 items per page
+	req := httptest.NewRequest(http.MethodGet, "/test-collection?page=1&pageSize=2", nil)
+	w := httptest.NewRecorder()
+
+	// Set path parameter as if from a router
+	req.SetPathValue(COLLECTION_NAME_PARAM, "test-collection")
+
+	// Execute the handler
+	srv.HandlerGetPaginatedCollectionItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 2, "Expected 2 items in paginated response")
+
+	assert.Equal(t, float64(1), responseBody["page"], "Expected page 1")
+	assert.Equal(t, float64(2), responseBody["pageSize"], "Expected pageSize 2")
+}
+
+// Test successful pagination for page 2 of a collection
+func TestHandlerGetPaginatedCollectionItems_Page2(t *testing.T) {
+	srv := &DareServer{
+		collectionManager: database.NewCollectionManager(),
+	}
+
+	// Mock a collection with multiple items
+	srv.collectionManager.AddCollection("test-collection")
+	collection, _ := srv.collectionManager.GetCollection("test-collection")
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+	collection.Set("key3", "value3")
+	collection.Set("key4", "value4")
+
+	// Simulate HTTP GET request for page 2 with 2 items per page
+	req := httptest.NewRequest(http.MethodGet, "/test-collection?page=2&pageSize=2", nil)
+	w := httptest.NewRecorder()
+
+	// Set path parameter as if from a router
+	req.SetPathValue(COLLECTION_NAME_PARAM, "test-collection")
+
+	// Execute the handler
+	srv.HandlerGetPaginatedCollectionItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 2, "Expected 2 items in paginated response")
+
+	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
+	assert.Equal(t, float64(2), responseBody["pageSize"], "Expected pageSize 2")
+}
+
+// Test handler when no items are available for the given page
+func TestHandlerGetPaginatedCollectionItems_EmptyPage(t *testing.T) {
+	srv := &DareServer{
+		collectionManager: database.NewCollectionManager(),
+	}
+
+	// Mock a collection with 2 items
+	srv.collectionManager.AddCollection("test-collection")
+	collection, _ := srv.collectionManager.GetCollection("test-collection")
+	collection.Set("key1", "value1")
+	collection.Set("key2", "value2")
+
+	// Simulate HTTP GET request for page 2 with 5 items per page (no data should exist for page 2)
+	req := httptest.NewRequest(http.MethodGet, "/test-collection?page=2&pageSize=5", nil)
+	w := httptest.NewRecorder()
+
+	// Set path parameter as if from a router
+	req.SetPathValue(COLLECTION_NAME_PARAM, "test-collection")
+
+	// Execute the handler
+	srv.HandlerGetPaginatedCollectionItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseBody map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseBody)
+	assert.NoError(t, err)
+
+	items := responseBody["items"].(map[string]interface{})
+	assert.Len(t, items, 0, "Expected 0 items for empty page")
+
+	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
+	assert.Equal(t, float64(5), responseBody["pageSize"], "Expected pageSize 5")
+}
+
+// Test handler for invalid method
+func TestHandlerGetPaginatedCollectionItems_InvalidMethod(t *testing.T) {
+	srv := &DareServer{
+		collectionManager: database.NewCollectionManager(),
+	}
+
+	// Simulate HTTP POST request (invalid method)
+	req := httptest.NewRequest(http.MethodPost, "/test-collection", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the handler
+	srv.HandlerGetPaginatedCollectionItems(w, req)
+
+	// Assert the response
+	resp := w.Result()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "Expected status 405 Method Not Allowed")
+}

--- a/server/dare-server_test.go
+++ b/server/dare-server_test.go
@@ -516,7 +516,8 @@ func TestHandlerGetPaginatedItems_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Execute the handler
-	srv.HandlerGetPaginatedItems(w, req)
+	req.SetPathValue(COLLECTION_NAME_PARAM, "default")
+	srv.HandlerGetPaginatedCollectionItems(w, req)
 
 	// Assert the response
 	resp := w.Result()
@@ -526,7 +527,7 @@ func TestHandlerGetPaginatedItems_Success(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 2, "Expected 2 items in paginated response")
 
 	assert.Equal(t, float64(1), responseBody["page"], "Expected page 1")
@@ -552,7 +553,8 @@ func TestHandlerGetPaginatedItems_Page2(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Execute the handler
-	srv.HandlerGetPaginatedItems(w, req)
+	req.SetPathValue(COLLECTION_NAME_PARAM, "default")
+	srv.HandlerGetPaginatedCollectionItems(w, req)
 
 	// Assert the response
 	resp := w.Result()
@@ -562,7 +564,7 @@ func TestHandlerGetPaginatedItems_Page2(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 2, "Expected 2 items in paginated response")
 
 	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
@@ -587,7 +589,8 @@ func TestHandlerGetPaginatedItems_EmptyPage(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Execute the handler
-	srv.HandlerGetPaginatedItems(w, req)
+	req.SetPathValue(COLLECTION_NAME_PARAM, "default")
+	srv.HandlerGetPaginatedCollectionItems(w, req)
 
 	// Assert the response
 	resp := w.Result()
@@ -597,7 +600,7 @@ func TestHandlerGetPaginatedItems_EmptyPage(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 0, "Expected 0 items for empty page")
 
 	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
@@ -617,7 +620,8 @@ func TestHandlerGetPaginatedItems_InvalidMethod(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Execute the handler
-	srv.HandlerGetPaginatedItems(w, req)
+	req.SetPathValue(COLLECTION_NAME_PARAM, "default")
+	srv.HandlerGetPaginatedCollectionItems(w, req)
 
 	// Assert the response
 	resp := w.Result()
@@ -655,7 +659,7 @@ func TestHandlerGetPaginatedCollectionItems_Success(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 2, "Expected 2 items in paginated response")
 
 	assert.Equal(t, float64(1), responseBody["page"], "Expected page 1")
@@ -694,7 +698,7 @@ func TestHandlerGetPaginatedCollectionItems_Page2(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 2, "Expected 2 items in paginated response")
 
 	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")
@@ -731,7 +735,7 @@ func TestHandlerGetPaginatedCollectionItems_EmptyPage(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&responseBody)
 	assert.NoError(t, err)
 
-	items := responseBody["items"].(map[string]interface{})
+	items := responseBody["items"].([]interface{})
 	assert.Len(t, items, 0, "Expected 0 items for empty page")
 
 	assert.Equal(t, float64(2), responseBody["page"], "Expected page 2")


### PR DESCRIPTION
Implemented the following HTTP endpoints for collection operations.

PART-A - Managing collections:

- GET `/collections`: List all collections (handled by HandlerGetCollections).
- GET `/collections/{collectionName}`: Get collection by name (handled by HandlerGetCollection).
- POST `/collections/{collectionName}`: Create a new collection (handled by HandlerCreateCollection).
- DELETE `/collections/{collectionName}`: Delete a collection (handled by HandlerDeleteCollection).


PART-B - Add/remove data collections:
- GET `/collections/{collectionName}/get/{key}`: Retrieve a value by key from a specified collection (handled by HandlerCollectionGetById).
- GET `/collections/{collectionName}/items`: Retrieve all collection items (paginated - pageSize and page parameters)
- POST `/collections/{collectionName}/set`: Set key-value pairs in a specified collection (handled by HandlerCollectionSet).
- DELETE `/collections/{collectionName}/delete/{key}`: Delete a key from a specified collection (handled by HandlerCollectionDelete).
- GET `/collections/{collectionName}/get/{key}`: Retrieve a specific key-value from a collection (handled by HandlerGetCollection).

